### PR TITLE
Data pipeline and DB tweaks

### DIFF
--- a/db.py
+++ b/db.py
@@ -29,11 +29,12 @@ class Outcome(Base):
     """
 
     __tablename__ = "outcomes"
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.String, primary_key=True)
     selection_name = db.Column(db.String)
     outcome_date = db.Column(db.Date)
     game_id = db.Column(db.Integer, db.ForeignKey("games.id"))
     result = db.Column(db.Integer)
+    runs = db.Column(db.Integer)
 
 
 class Wager(Base):
@@ -45,7 +46,7 @@ class Wager(Base):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
     wager_amount = db.Column(db.Integer)
-    outcome_id = db.Column(db.Integer, db.ForeignKey("games.id"))
+    outcome_id = db.Column(db.Integer, db.ForeignKey("outcomes.id"))
 
 
 class User(Base):

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+sqlalchemy
+MLB-StatsAPI

--- a/pipeline/scrape_data.py
+++ b/pipeline/scrape_data.py
@@ -46,7 +46,8 @@ def get_outcomes(games):
                 "selection_name": row[team],
                 "game_id": row["id"],
                 "result": _determine_result(row, row[team]),
-                "outcome_date": date.today()
+                "outcome_date": date.today(),
+                "runs": row[team.split("_")[0] + "_score"]
             }
             items.append(item)
     out = pd.DataFrame.from_records(items)

--- a/pipeline/scrape_data.py
+++ b/pipeline/scrape_data.py
@@ -1,0 +1,94 @@
+from argparse import ArgumentParser
+from datetime import date, timedelta
+
+import pandas as pd
+import statsapi
+
+
+OPENING_DAY = date(2022, 4, 7)
+
+COL_NAMES = {
+    "game_id": "id",
+    "home_name": "home_team",
+    "away_name": "away_team",
+    "game_date": "date",
+    "doubleheader": "dh"
+}
+SCHED_COLS = ["id", "home_team", "away_team", "date", "season", "week", "dh"]
+
+
+def _week_of_season(date_):
+    # Opening day is a Thursday, let's call that week 0 and increment on Mondays
+    od_week_no = date.isocalendar(OPENING_DAY)[1]
+    date_week_no = date.isocalendar(date_)[1]
+    return date_week_no - od_week_no
+
+
+def _determine_result(row, selection):
+    status = row["status"]
+    if "Final" not in status and "Completed" not in status:
+        return -1  # not complete
+    # spring training ties not always indicated in status,
+    # so check equivalence of scores
+    if row["home_score"] == row["away_score"]:
+        return 2  # tie
+    # otherwise compare winning team to selection team
+    # 1 = selection won, 0 = selection lost
+    return 1 if row["winning_team"] == selection else 0
+
+
+def get_outcomes(games):
+    items = list()
+    for _, row in games.iterrows():
+        for i, team in enumerate(("home_team", "away_team")):
+            item = {
+                "id": f"{row['id']}-{i}",
+                "selection_name": row[team],
+                "game_id": row["id"],
+                "result": _determine_result(row, row[team]),
+                "outcome_date": date.today()
+            }
+            items.append(item)
+    out = pd.DataFrame.from_records(items)
+    out.result = out.result.astype("Int64")
+    out.outcome_date = pd.to_datetime(out.outcome_date).dt.date
+    return out.set_index("id")
+
+
+def get_schedule(games):
+    return games[SCHED_COLS].set_index("id")
+
+
+def clean_data(data):
+    games = pd.DataFrame.from_records(data)
+    games = games.rename(COL_NAMES, axis=1)
+    games["date"] = pd.to_datetime(games["date"]).dt.date
+    games["dh"] = games["dh"].replace(dict(Y=1, N=0))
+    games["season"] = OPENING_DAY.year
+    games["week"] = games["date"].apply(_week_of_season)
+    return games
+
+
+def main(date_str=None):
+    if date_str is None:
+        today = date.today()
+    else:
+        today = date.fromisoformat(date_str)
+    yesterday = today - timedelta(days=1)
+    end_day = today + timedelta(days=6)
+    data = statsapi.schedule(start_date=yesterday, end_date=end_day)
+    games = clean_data(data)
+    outcomes = get_outcomes(games)
+    schedule = get_schedule(games)
+    schedule.to_csv(f"schedule_{today.isoformat()}.csv")
+    outcomes.to_csv(f"outcomes_{today.isoformat()}.csv")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Scrape schedule and outcome data for uecker-bot.")
+    parser.add_argument("--date",
+                        help="Date to scrape schedules around in YYYY-MM-DD format",
+                        default=None, required=False)
+    args = parser.parse_args()
+    main(args.date)
+

--- a/pipeline/update_db.py
+++ b/pipeline/update_db.py
@@ -1,0 +1,53 @@
+import os
+from datetime import date
+from argparse import ArgumentParser
+
+import sqlalchemy
+import pandas as pd
+
+
+DB_CONN_URI = os.environ.get("DB_CONN_URI", "sqlite:///main.db")
+GAMES_TABLE = os.environ.get("GAMES_TABLE", "games")
+OUTCOMES_TABLE = os.environ.get("OUTCOMES_TABLE", "outcomes")
+DATA_DIR = os.environ.get("UECKER_DATA_DIR", ".")
+
+
+def load_data(date_str):
+    games = pd.read_csv(os.path.join(DATA_DIR, f"schedule_{date_str}.csv"))
+    outcomes = pd.read_csv(os.path.join(DATA_DIR, f"outcomes_{date_str}.csv"))
+    return games, outcomes
+
+
+def get_db_connection():
+    eng = sqlalchemy.create_engine(DB_CONN_URI)
+    return eng
+
+
+def update_table(data, table, eng):
+    with eng.begin() as conn:
+        # create temporary table with new data
+        data.to_sql("tmp", conn, index=False, if_exists="replace")
+        # remove those rows from games
+        stmt = f"DELETE FROM {table} WHERE id IN (SELECT id FROM tmp);"
+        conn.execute(stmt)
+        # insert new data into games
+        data.to_sql(table, conn, index=False, if_exists="append")
+        conn.execute("DROP TABLE tmp;")
+
+
+def main(date_str=None):
+    eng = get_db_connection()
+    if date_str is None:
+        date_str = date.today().isoformat()
+    games, outcomes = load_data(date_str)
+    update_table(games, GAMES_TABLE, eng)
+    update_table(outcomes, OUTCOMES_TABLE, eng)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Ingest scraped data into uecker-bot database.")
+    parser.add_argument("--date",
+                        help="Date of data files in YYYY-MM-DD format",
+                        default=None, required=False)
+    args = parser.parse_args()
+    main(args.date)


### PR DESCRIPTION
I've written two small programs: one to scrape the schedule/results from MLB, the other to update the database for the bot.

The only big choice I wasn't sure on was how many days in advance to scrape. I went with one week, so the scraper makes one API request spanning games from eight days: one day before (to get final scores) through seven days in the future. We can easily change this behavior to whatever you guys think is best.

I tested it with spring training games. After running both programs, here is an example of the database state:
```
sqlite> SELECT * FROM games ORDER BY id LIMIT 5;
id          home_team             away_team            date        season      week        dh
----------  --------------------  -------------------  ----------  ----------  ----------  ----------
706786      Washington Nationals  St. Louis Cardinals  2022-03-30  2022        -1          0
706788      Washington Nationals  Miami Marlins        2022-03-28  2022        -1          0
706795      Toronto Blue Jays     Detroit Tigers       2022-03-31  2022        -1          0
706796      Toronto Blue Jays     Philadelphia Philli  2022-03-27  2022        -2          0
706799      Toronto Blue Jays     Detroit Tigers       2022-03-25  2022        -2          0
sqlite> SELECT * FROM outcomes ORDER BY game_id LIMIT 10;
id          selection_name        outcome_date  game_id     result      runs
----------  --------------------  ------------  ----------  ----------  ----------
706786-0    Washington Nationals  2022-03-26    706786      -1          0
706786-1    St. Louis Cardinals   2022-03-26    706786      -1          0
706788-0    Washington Nationals  2022-03-26    706788      -1          0
706788-1    Miami Marlins         2022-03-26    706788      -1          0
706795-0    Toronto Blue Jays     2022-03-26    706795      -1          0
706795-1    Detroit Tigers        2022-03-26    706795      -1          0
706796-0    Toronto Blue Jays     2022-03-26    706796      -1          0
706796-1    Philadelphia Phillie  2022-03-26    706796      -1          0
706799-0    Toronto Blue Jays     2022-03-26    706799      0           4
706799-1    Detroit Tigers        2022-03-26    706799      1           8
```
Each game has one row in `games` and two in `outcomes` corresponding to the two possible results. When the game is over, `outcomes.result` is set 1 if the selected team won, and 0 if not (and -1 for games yet-to-be-played). I added runs to the schema too.