### PR TITLE
Allow scraper to be deployed as AWS Lambda

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,0 +1,12 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY scrape_data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+COPY aws_requirements.txt  .
+RUN  pip3 install -r aws_requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "scrape_data.lambda_handler" ]

--- a/pipeline/aws_requirements.txt
+++ b/pipeline/aws_requirements.txt
@@ -1,0 +1,5 @@
+boto3==1.13.11
+fsspec
+s3fs
+pandas
+MLB-StatsAPI


### PR DESCRIPTION
- Refactors `scrape_data.py` to write to either filesystem or S3 bucket
- Provides Dockerfile and Python reqs to build container for Lambda runtime

I went ahead and deployed it, and it will run every day at 3 AM Eastern (7 AM GMT for now). The output is in a public S3 bucket called `uecker-bot`; the files should be downloadable from links like: https://uecker-bot.s3.amazonaws.com/schedule_2022-03-28.csv (maybe try to download that one to make sure) 