### PR TITLE
Handle rescheduled games

### DIFF
--- a/db.py
+++ b/db.py
@@ -19,6 +19,7 @@ class Game(Base):
     season = db.Column(db.Integer)
     week = db.Column(db.Integer)
     dh = db.Column(db.Integer)
+    date_changed = db.Column(db.Boolean)
     outcomes = relationship("Outcome", back_populates="game")
 
 

--- a/db.py
+++ b/db.py
@@ -35,6 +35,7 @@ class Outcome(Base):
     game_id = db.Column(db.Integer, db.ForeignKey("games.id"))
     result = db.Column(db.Integer)
     runs = db.Column(db.Integer)
+    game = relationship("Game", back_populates="outcomes")
 
 
 class Wager(Base):
@@ -47,6 +48,7 @@ class Wager(Base):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
     wager_amount = db.Column(db.Integer)
     outcome_id = db.Column(db.Integer, db.ForeignKey("outcomes.id"))
+    settled = db.Column(db.Boolean, default=False)
 
 
 class User(Base):

--- a/db.py
+++ b/db.py
@@ -6,6 +6,10 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 
+engine = db.create_engine(os.environ.get("DB_CONN_URI", "sqlite:///main.db"))
+Session = sessionmaker(engine)
+
+
 class Game(Base):
     """
     Available games to be wagered upon, and other metadata
@@ -102,11 +106,6 @@ class UserBonus(Base):
 
 
 def main():
-    DB_CONN_URI = os.environ.get("DB_CONN_URI", "sqlite:///main.db")
-    engine = db.create_engine(DB_CONN_URI)
-    Session = sessionmaker()
-    Session.configure(bind=engine)
-    session = Session()
     Base.metadata.create_all(engine)
 
 

--- a/pipeline/scrape_data.py
+++ b/pipeline/scrape_data.py
@@ -15,7 +15,16 @@ COL_NAMES = {
     "game_date": "date",
     "doubleheader": "dh",
 }
-SCHED_COLS = ["id", "home_team", "away_team", "date", "season", "week", "dh"]
+SCHED_COLS = [
+    "id",
+    "home_team",
+    "away_team",
+    "date",
+    "season",
+    "week",
+    "dh",
+    "date_changed",
+]
 DATA_DIR = os.environ.get("UECKER_DATA_DIR", "output")
 
 
@@ -59,6 +68,7 @@ def get_outcomes(games):
 
 
 def get_schedule(games):
+    games["date_changed"] = games.status.isin(("Postponed", "Suspended", "Cancelled"))
     return games[SCHED_COLS].set_index("id")
 
 


### PR DESCRIPTION
Implements the approach outlined by @michaelmountain-8451 in the Discord channel today. If a game is marked as postponed, suspended, or cancelled in the API data, it's flagged as such in `games.date_changed` and its date is set to null. Whenever it shows back up in the schedule, the date is updated.

Meanwhile, when the job that pays out wagers runs, it will check for games with`date_changed`, refund those wagers, and then set that column to False when complete.

This also resolves the messy approach of bulk deleting and re-inserting every morning. If a `game` or `outcome` already exists in the DB, it's updated. Otherwise it's inserted.